### PR TITLE
build: remove semrel dev deps

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -34,6 +34,19 @@ jobs:
         fail_ci_if_error: true # optional (default = false)
     - name: Semantic Release
       uses: cycjimmy/semantic-release-action@v2
+      with:
+        extra_plugins: |
+          @semantic-release/changelog
+          @semantic-release/commit-analyzer
+          @semantic-release/github
+          @semantic-release/git
+          @semantic-release/exec
+          @semantic-release/npm
+          @semantic-release/release-notes-generator
+        branches: |
+          [
+            'master',
+          ]
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -43,13 +43,6 @@
     "ws": "^8.0.0"
   },
   "devDependencies": {
-    "@semantic-release/changelog": "^6.0.0",
-    "@semantic-release/commit-analyzer": "^9.0.1",
-    "@semantic-release/exec": "^6.0.1",
-    "@semantic-release/git": "^10.0.0",
-    "@semantic-release/github": "^8.0.1",
-    "@semantic-release/npm": "^8.0.0",
-    "@semantic-release/release-notes-generator": "^10.0.2",
     "chai": "^4.2.0",
     "codecov": "^3.6.5",
     "eslint": "^7.19.0",


### PR DESCRIPTION
Semantic release is now used in CI action. No need for dev deps in package.json.